### PR TITLE
67 calendar lens fix

### DIFF
--- a/frontend/src/components/Lens/Calendar/calendar.tsx
+++ b/frontend/src/components/Lens/Calendar/calendar.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from "react";
+import React, { useState, useEffect } from "react";
 import Calendar from "react-calendar";
 import "./styles.css";
 
@@ -17,7 +17,8 @@ interface MapProps {
 }
 
 const MemoCalendar: React.FC<MapProps> = ({ locations }) => {
-  const [value, onChange] = useState(new Date());
+  const [value, setValue] = useState(new Date());
+  const [key, setKey] = useState(Date.now());
   const [selectedDateMemos, setSelectedDateMemos] = useState([]);
   const [isMemoOpen, setIsMemoOpen] = useState(false);
 
@@ -32,13 +33,16 @@ const MemoCalendar: React.FC<MapProps> = ({ locations }) => {
     return acc;
   }, {});
 
+  useEffect(() => {
+    setSelectedDateMemos(memosByDate[value.toDateString()] || []);
+    setIsMemoOpen(true);
+  }, [value]);
+
   const handleDateChange = (date) => {
-    if (date.toDateString() === value.toDateString()) {
-      setIsMemoOpen(!isMemoOpen);
+    if (date.toDateString() !== value.toDateString()) {
+      setValue(date);
     } else {
-      onChange(date);
-      setSelectedDateMemos(memosByDate[date.toDateString()] || []);
-      setIsMemoOpen(true);
+      setIsMemoOpen(!isMemoOpen);
     }
   };
 
@@ -46,6 +50,7 @@ const MemoCalendar: React.FC<MapProps> = ({ locations }) => {
     <>
       <div className="bg-blue-50 mt-4 mb-8 p-8 rounded-xl">
         <Calendar
+          key={key}
           onChange={handleDateChange}
           value={value}
           tileContent={({ date, view }) =>
@@ -54,6 +59,12 @@ const MemoCalendar: React.FC<MapProps> = ({ locations }) => {
             ) : null
           }
         />
+      <button onClick={() => {
+        setValue(new Date());
+        setKey(Date.now());
+      }} className="mt-4 border-blue-800 bg-blue-200">
+        Back to Current Date
+      </button>
       </div>
       {isMemoOpen && (
         <div className="mb-2">
@@ -63,7 +74,7 @@ const MemoCalendar: React.FC<MapProps> = ({ locations }) => {
       <ul>
         {isMemoOpen &&
           selectedDateMemos.map((memo, index) => (
-            <li key={index} className="bg-blue-50">
+            <li key={index} style={{ cursor: 'default', backgroundColor: '#EFF6FF'}}>
               {memo.title}
             </li>
           ))}

--- a/frontend/src/components/Lens/Calendar/calendar.tsx
+++ b/frontend/src/components/Lens/Calendar/calendar.tsx
@@ -58,6 +58,9 @@ const MemoCalendar: React.FC<MapProps> = ({ locations }) => {
               <p className="memo-tile">{memosByDate[date.toDateString()].length} memos</p>
             ) : null
           }
+          tileClassName={({ date, view }) =>
+            view === "month" && date.toDateString() === new Date().toDateString() ? "current-date" : ""
+          }
         />
       <button onClick={() => {
         setValue(new Date());

--- a/frontend/src/components/Lens/Calendar/calendar.tsx
+++ b/frontend/src/components/Lens/Calendar/calendar.tsx
@@ -65,7 +65,7 @@ const MemoCalendar: React.FC<MapProps> = ({ locations }) => {
       <button onClick={() => {
         setValue(new Date());
         setKey(Date.now());
-      }} className="mt-4 border-blue-800 bg-blue-200">
+      }} className="mt-4 border-blue-900 bg-blue-50">
         Back to Current Date
       </button>
       </div>

--- a/frontend/src/components/Lens/Calendar/styles.css
+++ b/frontend/src/components/Lens/Calendar/styles.css
@@ -7,3 +7,7 @@
     font-size: 12px;
 
 }
+
+.current-date {
+    background-color: red;
+}

--- a/frontend/src/components/Lens/Calendar/styles.css
+++ b/frontend/src/components/Lens/Calendar/styles.css
@@ -9,5 +9,5 @@
 }
 
 .current-date {
-    background-color: red;
+    background-color: #bae6fd !important;
 }

--- a/frontend/src/components/Lens/Map/table.tsx
+++ b/frontend/src/components/Lens/Map/table.tsx
@@ -24,7 +24,7 @@ const Table: React.FC<MapProps> = ({ locations }) => {
               <span className="text-blue-100">Title</span>
             </th>
             <th className="px-16 py-2">
-              <span className="text-blue-100">Memo</span>
+              <span className="text-blue-100">Location</span>
             </th>
             <th className="px-16 py-2">
               <span className="text-blue-100">Date</span>
@@ -36,7 +36,7 @@ const Table: React.FC<MapProps> = ({ locations }) => {
             location.memo.map((memo, memoIndex) => (
               <tr key={`${locIndex}-${memoIndex}`} className="bg-blue-100">
                 <td className="px-16 py-2 font-bold">{memo.title}</td>
-                <td className="px-16 py-2">{memo.description}</td>
+                <td className="px-16 py-2">{memo.location}</td>
                 <td className="px-16 py-2">{memo.date}</td>
               </tr>
             ))

--- a/frontend/src/components/Lens/page.tsx
+++ b/frontend/src/components/Lens/page.tsx
@@ -67,12 +67,13 @@ const Lens: React.FC = () => {
   return (
     <div className="lens w-2/3 text-left m-auto mt-10 bg-blue-200 p-10 pr-20 pl-20 rounded-3xl border-2 border-blue-800">
       <Header />
+
       <div id="lens-header" className="flex flex-row justify-between">
         <h1 className="text-blue-800 text-3xl mb-4">Lens</h1>
         <div>
           <button
             onClick={() => setView("map")}
-            className={`button-link text-blue-800 bg-blue-100 hover:bg-blue-300 border-blue-800 border-2 p-2 text-center rounded-lg ${
+            className={`button-link text-blue-800 bg-blue-100 hover:bg-blue-300 border-blue-800 border-2 p-2 text-center rounded-lg w-24 ${
               view === "map" ? "bg-blue-300" : ""
             }`}
           >
@@ -80,7 +81,7 @@ const Lens: React.FC = () => {
           </button>
           <button
             onClick={() => setView("list")}
-            className={`button-link text-blue-800 bg-blue-100 hover:bg-blue-300 border-blue-800 border-2 p-2 text-center rounded-lg ${
+            className={`button-link text-blue-800 bg-blue-100 hover:bg-blue-300 border-blue-800 border-2 p-2 text-center rounded-lg w-24 ${
               view === "list" ? "bg-blue-300" : ""
             }`}
           >
@@ -88,7 +89,7 @@ const Lens: React.FC = () => {
           </button>
           <button
             onClick={() => setView("calendar")}
-            className={`button-link text-blue-800 bg-blue-100 hover:bg-blue-300 border-blue-800 border-2 p-2 text-center rounded-lg ${
+            className={`button-link text-blue-800 bg-blue-100 hover:bg-blue-300 border-blue-800 border-2 p-2 text-center rounded-lg w-24 ${
               view === "calendar" ? "bg-blue-300" : ""
             }`}
           >
@@ -96,6 +97,7 @@ const Lens: React.FC = () => {
           </button>
         </div>
       </div>
+
       <link rel="stylesheet" href="https://unpkg.com/leaflet/dist/leaflet.css" />
       {(() => {
         switch (view) {

--- a/frontend/src/components/Lens/style.css
+++ b/frontend/src/components/Lens/style.css
@@ -13,20 +13,7 @@ div {
     padding: 0;
     margin: 0;
   }
-  
-  li {
-    background-color: #f0f0f0;
-    border: 1px solid #ccc;
-    margin: 8px;
-    padding: 12px;
-    cursor: pointer;
-    transition: background-color 0.3s ease;
-  }
-  
-  li:hover {
-    background-color: #e0e0e0;
-  }
-  
+    
   /* Styling for the Selected Memo */
   h2 {
     font-size: 20px;


### PR DESCRIPTION
- Added current date highlighting
- Added a button below the calendar to let the user nav back to the current date and current month/year calendar page
- Fixed date selection issue by setting a default auto-selection to the current date (lol)
- On map view, changed the second column to show memo location rather than memo, since a memo can be very long and thus would bloat the table. 